### PR TITLE
[#EDCO-24] Add ghaction to deploy on npm

### DIFF
--- a/.github/workflows/publish_to_npm.yml
+++ b/.github/workflows/publish_to_npm.yml
@@ -1,0 +1,24 @@
+name: Publish to NPM
+run-name: ${{ github.actor }} is publishing to NPM 🚀
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - run: yarn install
+      - run: yarn build
+      - run: cp package.json ./dist
+      - run: cp README.md ./dist
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}
+          package: dist/package.json
+          access: public
+          check-version: true


### PR DESCRIPTION
Added a pipeline to publish on npm (WIP).

Some consideration:
- this pipeline (now) isn't triggered by an automated event
- the version of the npm's release is drived by the version setted on the Package.json