### PR TITLE
[EDCO-28]: BannerLink nullish decoration check

### DIFF
--- a/src/components/BannerLink/BannerLink.tsx
+++ b/src/components/BannerLink/BannerLink.tsx
@@ -4,11 +4,16 @@ import { type Generic, type CommonProps } from 'types/components';
 import { type BannerLinkContentProps, Content } from './Content';
 import { isJSX } from '../../utils';
 
+type ImgProps = React.DetailedHTMLProps<
+  React.ImgHTMLAttributes<HTMLImageElement>,
+  HTMLImageElement
+>;
+
 export interface BannerLinkProps
   extends CommonProps,
     BannerLinkContentProps,
     CtaProps {
-  decoration?: string | Generic;
+  decoration?: ImgProps | Generic;
 }
 
 export const BannerLink = ({
@@ -27,11 +32,13 @@ export const BannerLink = ({
     <Box bgcolor={backgroundColor}>
       <Container>
         <Stack gap={4} sx={styles.main}>
-          {isJSX(decoration) ? (
-            decoration
-          ) : (
-            <img src={decoration} alt="Banner Icon" />
-          )}
+          {decoration ? (
+            isJSX(decoration) ? (
+              decoration
+            ) : (
+              <img {...decoration} />
+            )
+          ) : null}
           <BannerLink.Content {...{ body, title, theme }} />
           {ctaButtons?.length && <Ctas theme={theme} ctaButtons={ctaButtons} />}
         </Stack>

--- a/src/stories/BannerLink/dark.stories.tsx
+++ b/src/stories/BannerLink/dark.stories.tsx
@@ -40,12 +40,12 @@ TwoButtons.args = {
 
 export const WithIcon = Template.bind({});
 WithIcon.args = {
-  decoration: LoginWhite,
+  decoration: { src: LoginWhite, alt: 'Login' },
 };
 
 export const TwoButtonsAndIcon = Template.bind({});
 TwoButtonsAndIcon.args = {
-  decoration: LoginWhite,
+  decoration: { src: LoginWhite, alt: 'Login' },
   ctaButtons: defaults.ctaButtons,
 };
 

--- a/src/stories/BannerLink/light.stories.tsx
+++ b/src/stories/BannerLink/light.stories.tsx
@@ -37,12 +37,12 @@ TwoButtons.args = {
 
 export const WithIcon = Template.bind({});
 WithIcon.args = {
-  decoration: Login,
+  decoration: { src: Login, alt: 'Login' },
 };
 
 export const TwoButtonsAndIcon = Template.bind({});
 TwoButtonsAndIcon.args = {
-  decoration: Login,
+  decoration: { src: Login, alt: 'Login' },
   ctaButtons: defaults.ctaButtons,
 };
 


### PR DESCRIPTION
## Description
- BannerLink checks if decoration is nullish before rendering.
- Changed decoration type to:   decoration?: ImgProps | Generic;

Fixes # (edco-28)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Storybook
- [x] Visual testing
- [x] Local build npm install
