### PR TITLE
[EDCO-37] Making the header's product clickable

### DIFF
--- a/src/components/Header/components/Title.tsx
+++ b/src/components/Header/components/Title.tsx
@@ -5,16 +5,25 @@ import {
   Chip,
   type AvatarProps,
   useTheme,
+  Link,
 } from '@mui/material';
 import { type CommonProps } from '../../../types/components';
 
 export interface TitleProps extends CommonProps {
-  product: string;
+  product: {
+    name: string;
+    href?: string;
+  };
   avatar?: AvatarProps;
   beta?: boolean;
 }
 
-export const Content = ({ avatar, beta, product, theme }: TitleProps) => {
+export const Content = ({
+  avatar,
+  beta,
+  product: { name: productName, href: productHref },
+  theme,
+}: TitleProps) => {
   const { palette, spacing } = useTheme();
   const textColor =
     theme === 'dark' ? palette.primary.contrastText : palette.text.primary;
@@ -29,7 +38,13 @@ export const Content = ({ avatar, beta, product, theme }: TitleProps) => {
         noWrap
         variant="h5"
       >
-        <b>{product}</b>
+        {productHref ? (
+          <Link href={productHref} underline="none" color="text.primary">
+            <b>{productName}</b>
+          </Link>
+        ) : (
+          <b>{productName}</b>
+        )}
       </Typography>
       {beta && (
         <Chip

--- a/src/stories/Header/defaults.tsx
+++ b/src/stories/Header/defaults.tsx
@@ -11,7 +11,10 @@ export const defaults: {
 } = {
   args: {
     theme: 'light',
-    product: 'Nome del prodotto',
+    product: {
+      name: 'Nome del prodotto',
+      href: '/',
+    },
     menu: [
       {
         theme: 'light',


### PR DESCRIPTION
## Description
Added a conditional href property to the header's product to make it clickable

Fixes # [edco-37](https://pagopa.atlassian.net/browse/EDCO-37)

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Storybook
- [x] Visual testing
- [x] Local build install