### PR TITLE
[EDCO-38] React.FC type remotion

### DIFF
--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Box, Container, Grid, Stack, Typography } from '@mui/material';
 import { AccordionItem, type AccordionItemProps } from './AccordionItem';
 export interface AccordionProps {
@@ -11,14 +10,15 @@ export interface AccordionProps {
   layout?: 'left' | 'center' | 'right';
 }
 
-export const Accordion: React.FC<AccordionProps> = ({
-  title,
-  subtitle,
-  description,
-  accordionItems,
-  theme,
-  layout = 'left',
-}) => {
+export const Accordion = (props: AccordionProps) => {
+  const {
+    title,
+    subtitle,
+    description,
+    accordionItems,
+    theme,
+    layout = 'left',
+  } = props;
   const isDarkTheme = theme === 'dark';
   const bgcolor = isDarkTheme ? 'primary.main' : '#FAFAFA';
   const textColor = isDarkTheme ? 'white' : 'text.primary';

--- a/src/components/BannerLink/BannerLink.tsx
+++ b/src/components/BannerLink/BannerLink.tsx
@@ -1,7 +1,10 @@
 import { alpha, Box, Container, Stack, useTheme } from '@mui/material';
 import { Ctas, type CtaProps } from '../../components/Ctas';
 import { type Generic, type CommonProps } from 'types/components';
-import { type BannerLinkContentProps, Content } from './Content';
+import {
+  type BannerLinkContentProps,
+  Content as BannerLinkContent,
+} from './Content';
 import { isJSX } from '../../utils';
 
 type ImgProps = React.DetailedHTMLProps<
@@ -16,13 +19,8 @@ export interface BannerLinkProps
   decoration?: ImgProps | Generic;
 }
 
-export const BannerLink = ({
-  theme,
-  body,
-  title,
-  ctaButtons,
-  decoration = <></>,
-}: BannerLinkProps) => {
+export const BannerLink = (props: BannerLinkProps) => {
+  const { theme, body, title, ctaButtons, decoration = <></> } = props;
   const { palette } = useTheme();
 
   const backgroundColor =
@@ -39,15 +37,13 @@ export const BannerLink = ({
               <img {...decoration} />
             )
           ) : null}
-          <BannerLink.Content {...{ body, title, theme }} />
+          <BannerLinkContent {...{ body, title, theme }} />
           {ctaButtons?.length && <Ctas theme={theme} ctaButtons={ctaButtons} />}
         </Stack>
       </Container>
     </Box>
   );
 };
-
-BannerLink.Content = Content;
 
 const styles = {
   main: {

--- a/src/components/Editorial/Editorial.tsx
+++ b/src/components/Editorial/Editorial.tsx
@@ -2,9 +2,12 @@ import Grid from '@mui/material/Grid';
 import Stack from '@mui/material/Stack';
 import { useTheme } from '@mui/material/styles';
 import { type CommonProps } from 'types/components';
-import { Content, type EditorialContentProps } from './Content';
-import { Ctas, type EditorialCtaProps } from './Ctas';
-import { Image, type EditorialImageProps } from './Image';
+import {
+  Content as EditorialContent,
+  type EditorialContentProps,
+} from './Content';
+import { Ctas as EditorialCtas, type EditorialCtaProps } from './Ctas';
+import { Image as EditorialImage, type EditorialImageProps } from './Image';
 import EContainer from '../EContainer';
 
 export interface EditorialProps
@@ -16,17 +19,18 @@ export interface EditorialProps
   width: 'wide' | 'standard' | 'center';
 }
 
-export const Editorial = ({
-  image,
-  eyelet,
-  title,
-  body,
-  theme,
-  ctaButtons,
-  reversed,
-  pattern = 'none',
-  width = 'standard',
-}: EditorialProps) => {
+export const Editorial = (props: EditorialProps) => {
+  const {
+    image,
+    eyelet,
+    title,
+    body,
+    theme,
+    ctaButtons,
+    reversed,
+    pattern = 'none',
+    width = 'standard',
+  } = props;
   const { palette } = useTheme();
 
   const backgroundColor =
@@ -51,20 +55,16 @@ export const Editorial = ({
     >
       <Grid item md={columns[width]} sx={styles.half}>
         <Stack gap={4}>
-          <Editorial.Content {...{ eyelet, body, title, theme }} />
-          <Editorial.Ctas {...{ ctaButtons, theme }} />
+          <EditorialContent {...{ eyelet, body, title, theme }} />
+          <EditorialCtas {...{ ctaButtons, theme }} />
         </Stack>
       </Grid>
       <Grid item md={columns[width]} sx={styles.half}>
-        <Editorial.Image {...{ pattern, image, theme }} />
+        <EditorialImage {...{ pattern, image, theme }} />
       </Grid>
     </EContainer>
   );
 };
-
-Editorial.Content = Content;
-Editorial.Ctas = Ctas;
-Editorial.Image = Image;
 
 const styles = {
   half: {

--- a/src/components/Feature/Feature.tsx
+++ b/src/components/Feature/Feature.tsx
@@ -22,13 +22,8 @@ export interface FeatureProps {
   background?: string;
 }
 
-const Feature: React.FC<FeatureProps> = ({
-  title,
-  items,
-  theme,
-  showCarouselMobile,
-  background,
-}: FeatureProps) => {
+const Feature = (props: FeatureProps) => {
+  const { title, items, theme, showCarouselMobile, background } = props;
   const [activeStep, setActiveStep] = useState(0);
   const themeComponent = useTheme();
 

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -32,16 +32,17 @@ type FooterProps = LangSwitchProps & {
   hideProductsColumn?: boolean;
 };
 
-export const Footer = ({
-  companyLink,
-  legalInfo,
-  links,
-  onExit,
-  productsJsonUrl = 'https://selfcare.pagopa.it/assets/products.json',
-  onProductsJsonFetchError,
-  hideProductsColumn,
-  ...langProps
-}: FooterProps): Generic => {
+export const Footer = (props: FooterProps) => {
+  const {
+    companyLink,
+    legalInfo,
+    links,
+    onExit,
+    productsJsonUrl = 'https://selfcare.pagopa.it/assets/products.json',
+    onProductsJsonFetchError,
+    hideProductsColumn,
+    ...langProps
+  } = props;
   const { aboutUs, resources, followUs } = links;
 
   const [jsonProducts, setJsonProducts] = useState<FooterLinksType[]>([]);

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -12,14 +12,8 @@ interface BottomHeaderProps extends CtaProps, NavigationProps, TitleProps {}
 
 export interface HeaderProps extends CommonProps, BottomHeaderProps {}
 
-export const Header = ({
-  product,
-  theme,
-  menu,
-  ctaButtons,
-  avatar,
-  beta,
-}: HeaderProps) => {
+export const Header = (props: HeaderProps) => {
+  const { product, theme, menu, ctaButtons, avatar, beta } = props;
   const [headerOpen, setHeaderOpen] = useState(false);
 
   const openHeader = () => {

--- a/src/components/HowTo/HowTo.tsx
+++ b/src/components/HowTo/HowTo.tsx
@@ -33,14 +33,15 @@ const groupStepsByRows = (steps: Step[], rowMaxSteps: number): Step[][] => {
     .map((_, i) => steps.slice(i * rowMaxSteps, i * rowMaxSteps + rowMaxSteps));
 };
 
-export const HowTo: React.FC<HowToProps> = ({
-  title,
-  steps,
-  theme,
-  link,
-  rowMaxSteps = 4,
-  stepsAlignment = 'center',
-}) => {
+export const HowTo = (props: HowToProps) => {
+  const {
+    title,
+    steps,
+    theme,
+    link,
+    rowMaxSteps = 4,
+    stepsAlignment = 'center',
+  } = props;
   const isDarkTheme = theme === 'dark';
   const background = isDarkTheme ? howToBackgroundDark : howToBackgroundLight;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import Hero from './components/Hero';
 import { HowTo } from './components/HowTo';
 import PhotoVideo from './components/PhotoVideo';
 
-export default {
+export {
   Accordion,
   BannerLink,
   Editorial,


### PR DESCRIPTION
## Description
With this PR a common approach is used to define the react components interface. The usage of React.FC is discouraged and for this reason removed from this repo. Now all components are exported as an object properties from the main entry point file (src/index.ts)

## Type of change
- [x] Breaking change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Storybook
- [x] Visual testing
- [x] Local build install