### PR TITLE
[EDCO-41] HowTo component: title centered

### DIFF
--- a/src/components/HowTo/HowTo.tsx
+++ b/src/components/HowTo/HowTo.tsx
@@ -71,7 +71,7 @@ export const HowTo = (props: HowToProps) => {
 
   return (
     <EContainer background={Background} py={{ xs: 6, md: 8 }}>
-      <Grid item>
+      <Grid item xs={12}>
         {/** Section title */}
         <Typography
           color={isDarkTheme ? 'white' : 'text.primary'}


### PR DESCRIPTION
## Description
a small fix to center the title of the HowTo component

Fixes # [edco-41](https://pagopa.atlassian.net/browse/EDCO-41)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Storybook
- [x] Visual testing