### PR TITLE
[EDCO-43] Jsx not rendered inside Typography

### DIFF
--- a/src/components/Editorial/Content.tsx
+++ b/src/components/Editorial/Content.tsx
@@ -2,6 +2,7 @@ import { useTheme } from '@mui/material';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { type CommonProps } from 'types/components';
+import { isJSX } from '../../utils';
 
 export interface EditorialContentProps extends CommonProps {
   title: string;
@@ -30,9 +31,13 @@ export const Content = ({
       <Typography color={textColor} variant="h4">
         {title}
       </Typography>
-      <Typography color={textColor} variant="body2">
-        {body}
-      </Typography>
+      {isJSX(body) ? (
+        body
+      ) : (
+        <Typography color={textColor} variant="body2">
+          {body}
+        </Typography>
+      )}
     </Stack>
   );
 };

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -7,7 +7,7 @@ import {
 } from './index';
 import { LangSwitch, type LangSwitchProps } from './LangSwitch';
 import { isRight, toError } from 'fp-ts/lib/Either';
-import { hrefNoOp, wrapHandleExitAction } from '../../utils/index';
+import { hrefNoOp, isJSX, wrapHandleExitAction } from '../../utils/index';
 
 /* Icons */
 import TwitterIcon from '@mui/icons-material/Twitter';
@@ -288,14 +288,17 @@ export const Footer = (props: FooterProps) => {
         }}
       >
         <Container sx={{ px: 2, py: 2 }}>
-          <Typography
-            color="text.primary"
-            component="p"
-            variant="caption"
-            textAlign="center"
-          >
-            {legalInfo}
-          </Typography>
+          {isJSX(legalInfo) ? (
+            legalInfo
+          ) : (
+            <Typography
+              color="text.primary"
+              variant="caption"
+              textAlign="center"
+            >
+              {legalInfo}
+            </Typography>
+          )}
         </Container>
       </Box>
     </Box>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -48,7 +48,9 @@ const HeroTextContent = ({
           <Typography variant="h1" color={textColor} mb={2}>
             {title}
           </Typography>
-          {subtitle && (
+          {isJSX(subtitle) ? (
+            subtitle
+          ) : (
             <Typography variant="body1" color={textColor}>
               {subtitle}
             </Typography>

--- a/src/stories/Hero/dark.stories.tsx
+++ b/src/stories/Hero/dark.stories.tsx
@@ -7,6 +7,7 @@ import {
   image,
 } from './heroCommons';
 import heroDarkSolidBackground from '../assets/hero-solid-dark.jpg';
+import Typography from '@mui/material/Typography';
 
 export default {
   title: 'Hero/dark',
@@ -39,6 +40,20 @@ HeroBigWithBackground.args = {
   background,
   size: 'big',
   ...defaults,
+};
+
+export const HeroHtmlBody = Template.bind({});
+HeroHtmlBody.args = {
+  ...defaults,
+  background,
+  subtitle: (
+    <Typography variant="body1" color="primary.contrastText">
+      Quis aute iure reprehenderit in <b>voluptate</b> velit esse cillum dolore
+      eu fugiat nulla pariatur. <b>Excepteur</b> sint obcaecat cupiditat non
+      proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </Typography>
+  ),
+  size: 'big',
 };
 
 export const HeroSmallWithBackground = Template.bind({});

--- a/src/stories/Hero/heroCommons.tsx
+++ b/src/stories/Hero/heroCommons.tsx
@@ -4,13 +4,9 @@ import hero_background_inverse from '../assets/hero_background_inverse.jpg';
 import hero_image from '../assets/hero_image.png';
 
 const title = 'Lorem ipsum dolor sit amet, consectetur';
-const subtitle = (
-  <>
-    Quis aute iure reprehenderit in <b>voluptate</b> velit esse cillum dolore eu
-    fugiat nulla pariatur. <b>Excepteur</b> sint obcaecat cupiditat non
-    proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-  </>
-);
+const subtitle = `Quis aute iure reprehenderit in voluptate velit esse cillum dolore eu
+    fugiat nulla pariatur. Excepteur sint obcaecat cupiditat non
+    proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`;
 
 export const heroCommonProps = {
   title,

--- a/src/stories/Hero/light.stories.tsx
+++ b/src/stories/Hero/light.stories.tsx
@@ -7,6 +7,7 @@ import {
   image,
 } from './heroCommons';
 import heroLightSolidBackground from '../assets/hero-solid-light.jpg';
+import Typography from '@mui/material/Typography/Typography';
 
 export default {
   title: 'Hero/light',
@@ -39,6 +40,20 @@ HeroBigWithBackground.args = {
   background,
   size: 'big',
   ...defaults,
+};
+
+export const HeroHtmlBody = Template.bind({});
+HeroHtmlBody.args = {
+  ...defaults,
+  background,
+  subtitle: (
+    <Typography variant="body1">
+      Quis aute iure reprehenderit in <b>voluptate</b> velit esse cillum dolore
+      eu fugiat nulla pariatur. <b>Excepteur</b> sint obcaecat cupiditat non
+      proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+    </Typography>
+  ),
+  size: 'big',
 };
 
 export const HeroSmallWithBackground = Template.bind({});


### PR DESCRIPTION
## Description
Jsx valid component are not rendered inside a typography tag

Fixes # [edco-40](https://pagopa.atlassian.net/browse/EDCO-43)

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Storybook
- [x] Visual testing
- [x] Local build install

