### PR TITLE
[EDCO-46]: html5 video tag, context menu and download hidden

### DIFF
--- a/src/components/PhotoVideo/YouTube.tsx
+++ b/src/components/PhotoVideo/YouTube.tsx
@@ -62,6 +62,10 @@ const YouTubeVideo = ({
       <Grid item xs={12} md={full ? 12 : 6}>
         {useYoutubeLayout ? (
           <video
+            onContextMenu={(e) => {
+              e.preventDefault();
+            }}
+            controlsList="nodownload"
             playsInline
             ref={videoRef}
             controls


### PR DESCRIPTION
## Description
Context menu prevented and download hidden to make video not downloadable by FE

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Storybook
- [x] Visual testing