### PR TITLE
fix: set component to div to avoid rendering errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Semantic Versioning Changelog
 
+## [2.3.2](https://github.com/pagopa/pagopa-editorial-components/compare/v2.3.1...v2.3.2) (2024-02-23)
+
+
+### Bug Fixes
+
+* set component to div to avoid rendering errors ([6746048](https://github.com/pagopa/pagopa-editorial-components/commit/67460487ea282e3b885e10f5013ab4f6e97f11a1))
+
 ## [2.3.1](https://github.com/pagopa/pagopa-editorial-components/compare/v2.3.0...v2.3.1) (2024-02-21)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/pagopa-editorial-components",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "author": {
     "name": "PagoPA"
   },

--- a/src/components/Cards/index.tsx
+++ b/src/components/Cards/index.tsx
@@ -63,6 +63,7 @@ const Cards = ({ items, theme, text }: CardsProps) => {
           width: { md: isMasonry ? '30%' : '100%', xs: '100%' },
           textAlign: isMasonry ? 'left' : 'center',
         }}
+        component={'div'}
       >
         <Typography variant="h2" mb={5} color={'inherit'}>
           {text.title}


### PR DESCRIPTION
## Short description
Add `component={'div'}` to solve issues when render the component on NextJS.

## Product
Please specify what product from which this feature originated (e.g: Piattaforma Notifiche, Area Riservata, etc…). Leave blank if it's not referred specifically to a single product.
B2B-portals