### PR TITLE
feat: [B2BP-514] - Remove "width" from interface IItem

### DIFF
--- a/src/components/Cards/item.tsx
+++ b/src/components/Cards/item.tsx
@@ -14,7 +14,6 @@ export interface IItem {
     title?: string;
   }>;
   masonry?: boolean;
-  width: string;
 }
 
 const Item = ({


### PR DESCRIPTION
## Short description
This PR will fix the Cards component when used outside EC. "Width" from interface IItem is unusued

## List of changes proposed in this pull request
- Removed "Width" from interface IItem

## Product

## How to test
Tested in local running the storybook. Then builded and passed the "dist" folder inside the B2BP project.
