### PR TITLE
feat: [B2BP-522] - added editorial badges as props

### DIFF
--- a/src/components/Editorial/Ctas.tsx
+++ b/src/components/Editorial/Ctas.tsx
@@ -14,6 +14,8 @@ type CtaButton = CtaButtonProps | JSX.Element;
 export interface StoreButtonsProps {
   hrefGoogle?: string;
   hrefApple?: string;
+  appleBadge?: string;
+  googleBadge?: string;
 }
 
 export interface EditorialCtaProps extends CommonProps {
@@ -68,7 +70,7 @@ export const Ctas = ({
             href={storeButtons.hrefGoogle}
           >
             <img
-              src={googleBadge}
+              src={googleBadge ?? googleBadge}
               alt="Download on the App Store"
               style={{ height: '3em' }}
             />
@@ -85,7 +87,7 @@ export const Ctas = ({
             href={storeButtons.hrefApple}
           >
             <img
-              src={appleBadge}
+              src={appleBadge ?? appleBadge}
               alt="Download on the App Store"
               style={{ height: '3em' }}
             />

--- a/src/components/Editorial/Ctas.tsx
+++ b/src/components/Editorial/Ctas.tsx
@@ -70,7 +70,7 @@ export const Ctas = ({
             href={storeButtons.hrefGoogle}
           >
             <img
-              src={googleBadge ?? googleBadge}
+              src={storeButtons.googleBadge ?? googleBadge}
               alt="Download on the App Store"
               style={{ height: '3em' }}
             />
@@ -87,7 +87,7 @@ export const Ctas = ({
             href={storeButtons.hrefApple}
           >
             <img
-              src={appleBadge ?? appleBadge}
+              src={storeButtons.appleBadge ?? appleBadge}
               alt="Download on the App Store"
               style={{ height: '3em' }}
             />


### PR DESCRIPTION
## Short description
Added the Editorial Badges as a props in addiction to the hardcoded value

## List of changes proposed in this pull request
- Added appleBadge and googleBadge as storeButtons props

## Product

## How to test
Tested in local running the storybook. Then builded and passed the "dist" folder inside the B2BP project.
